### PR TITLE
Ability to customize downloaded PDF filename (instead of "generated.pdf"). Optional param. Bumped version according to semver.org

### DIFF
--- a/lib/pdfcrowd.js
+++ b/lib/pdfcrowd.js
@@ -102,14 +102,15 @@ var saveToFile = function(fname) {
 //
 // Returns a callback object that sends the generated PDF in an HTTP response
 //
-var sendHttpResponse = function(response, disposition) {
+var sendHttpResponse = function(response, disposition, fname) {
     disposition = disposition || "attachment";
+    fname = fname || "generated.pdf";
     return {
         pdf: function(rstream) {
             response.setHeader("Content-Type", "application/pdf");
             response.setHeader("Cache-Control", "no-cache");
             response.setHeader("Accept-Ranges", "none");
-            response.setHeader("Content-Disposition", disposition + "; filename=\"generated.pdf\"");
+            response.setHeader("Content-Disposition", disposition + "; filename=\"" + fname + "\"");
             rstream.pipe(response);
         },
         error: function(errMessage, statusCode) { 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfcrowd",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:pdfcrowd/node-pdfcrowd.git"


### PR DESCRIPTION
...omize downloaded name, defaults to generated.pdf. Bumped version to 1.1.0 (bumped minor version, reset patch version, since it is a backwards compatible API change - i.e. http://semver.org/)
