### PR TITLE
Use HTTPS by default. Add `userStatus` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ username and an API key. Here is the
 To install via npm:
 
     $ npm install pdfcrowd
-    
+
 Or clone from GitHub and create a symlink in `~/.node_libraries`:
 
     $ git clone git@github.com:pdfcrowd/node-pdfcrowd.git
-    $ ln -s /path/to/node-pdfcrowd ~/.node_libraries/pdfcrowd    
+    $ ln -s /path/to/node-pdfcrowd ~/.node_libraries/pdfcrowd
 
-    
+
 Dependencies
 
 * http *native module*
@@ -36,19 +36,23 @@ HTTP
 
     var client = new pdf.Pdfcrowd('username', 'apikey');
     client.convertHtml('<html>regular HTML code</html>', pdf.sendHttpResponse(response));
-    
+
+If for some reason you want to disable https, pass `false` as the last argument:
+
+    var client = new pdf.Pdfcrowd('username', 'apikey', 'pdfcrowd.com', false);
+
 You can convert also a web page and save it to a file:
-    
+
     client.convertURI('http://example.com', pdf.saveToFile("example_com.pdf"));
 
 Or a local HTML file:
-    
+
     client.convertFile('/local/file.html', pdf.saveToFile("file.pdf"));
-    
+
 The generated PDF can be customized:
 
     client.convertURI(
-        'http://example.com', 
+        'http://example.com',
         pdf.saveToFile("example_com.pdf"),
         {
             width: "11in",
@@ -66,7 +70,7 @@ The generated PDF can be customized:
      new Pdfcrowd(username, apikey)
 
 Creates a Pdfcrowd instance.
-    
+
 ### Methods
 
      Pdfcrowd.convertHtml(html, callbacks [,options])
@@ -87,29 +91,29 @@ Converts a local HTML file to PDF.
 
         pdf(readableStream)
   Called when the PDF [stream](http://nodejs.org/docs/latest/api/streams.html#readable_Stream) becomes available.
-  
+
         end()
   Called when all PDF data has been read.
-        
+
         error(errorMessage, statusCode)
   Called when an error occurs. *errorMessage* is a string containing the error message and *statusCode* is a HTTP status code.
-  
+
 * The optional *options* argument lets you customize the created
   PDF. You can find the list of all options
   [here](https://pdfcrowd.com/html-to-pdf-api/#api-ref-conversion-common-par).
 
-    
+
 ### Helpers
 
 These functions return a callback object that can be passed to
 the methods above.
 
     saveToFile(fileName)
-    
+
 Saves the generated PDF to a file.
-    
+
     sendHttpResponse(response [,disposition])
-    
+
 Returns the generated PDF in an HTTP
 [response](http://nodejs.org/docs/latest/api/http.html#http.ServerResponse). *dispostion*
 can be `"attachment"` (default) or `"inline"`.
@@ -137,5 +141,5 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-    
+
 

--- a/lib/pdfcrowd.js
+++ b/lib/pdfcrowd.js
@@ -1,5 +1,5 @@
 // Copyright (C) 2011,2012 pdfcrowd.com
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
@@ -7,10 +7,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -20,11 +20,12 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var http = require('http')
+var https = require('https');
 var querystring = require('querystring');
 var fs = require('fs');
 
 
-var Pdfcrowd = function(username, apikey, host) {
+var Pdfcrowd = function(username, apikey, host, https) {
     if (!username)
         throw new Error('Missing username.');
 
@@ -34,7 +35,19 @@ var Pdfcrowd = function(username, apikey, host) {
     this.username = username;
     this.apikey = apikey;
     this.host = host || "pdfcrowd.com";
+    this.https = https || true;
 };
+
+
+//
+// Queries for the number of available credits
+//
+Pdfcrowd.prototype.userStatus = function(callback) {
+    requestQueue.addRequest([this, {
+        endpoint: '/api/user/' + this.username + '/tokens/',
+        callbacks: callback
+    }]);
+}
 
 
 //
@@ -89,7 +102,7 @@ Pdfcrowd.prototype.convertFile = function(fname, callbacks, options) {
 //
 var saveToFile = function(fname) {
     return {
-        pdf: function(rstream) { 
+        pdf: function(rstream) {
             var wstream = fs.createWriteStream(fname);
             rstream.pipe(wstream);
         },
@@ -113,7 +126,7 @@ var sendHttpResponse = function(response, disposition, fname) {
             response.setHeader("Content-Disposition", disposition + "; filename=\"" + fname + "\"");
             rstream.pipe(response);
         },
-        error: function(errMessage, statusCode) { 
+        error: function(errMessage, statusCode) {
             response.setHeader("Content-Type", "text/plain");
             response.end('ERROR: ' + errMessage);
         },
@@ -224,10 +237,17 @@ var convertInternal = function(that, opts) {
         postData = encodeMultipartPostData(postData, opts.fname, opts.data);
     }
 
+    var agent;
+    if (that.https) {
+        agent = https;
+    } else {
+        agent = http;
+    }
+
     // http options
     var httpOptions = {
         host: that.host,
-        port: 80,
+        port: that.https ? 443 : 80,
         method: 'POST',
         path: opts.endpoint,
         headers: { 'content-length': postData.length,
@@ -236,21 +256,27 @@ var convertInternal = function(that, opts) {
     };
 
     var callbacks = opts.callbacks;
-    var req = http.request(httpOptions, function(res) {
-        if (res.statusCode < 300) {
+    var req = agent.request(httpOptions, function(res) {
+        if (res.statusCode < 300 && callbacks.pdf) {
             res.on('end', function() {
                 callbacks.end();
                 requestQueue.requestDone();
             });
-
             res.on('error', function(exc) {
                 callbacks.error(exc.toString());
                 requestQueue.requestDone();
             });
-
             callbacks.pdf(res);
-        }
-        else {
+        } else if (res.statusCode < 300 && !callbacks.pdf) {
+            var chunks = [];
+            res.on('data', function(chunk) {
+                chunks.push(chunk.toString());
+            });
+            res.on('end', function() {
+                requestQueue.requestDone();
+                callbacks(chunks.join(''));
+            });
+        } else {
             var err = [];
             res.on('data', function(chunk) {
                 err.push(chunk.toString());

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -23,10 +23,11 @@ function out_stream(name) {
     return pdf.saveToFile("../test_files/out/node_client_" + name);
 }
 
+myPdfcrowd.userStatus(function(res) {
+    console.log('Remaining credits:', res);
+});
 myPdfcrowd.convertFile("sample.html.zip", out_stream("zfile.pdf"), apiOptions);
 myPdfcrowd.convertHtml("raw code", out_stream("html.pdf"));
 myPdfcrowd.convertURI("http://example.com", out_stream("url.pdf"));
 myPdfcrowd.convertFile("sample.html", out_stream("file.pdf"));
 myPdfcrowd.convertHtml('footer example', out_stream("footer.pdf"), apiOptions);
-
-


### PR DESCRIPTION
This PR adds two functionalities to the package:
- Uses HTTPS for API requests (this is 2017!)
- Provides a `pdfCrowd.userStatus()` method to check for one's remaining credits.
